### PR TITLE
Add multi-zone and wildcard support for CloudCaddy DDNS

### DIFF
--- a/ddns.sh
+++ b/ddns.sh
@@ -1,71 +1,128 @@
 #!/bin/bash
 
-# === Load configuration ===
-ENV_FILE="/opt/cloudflare-ddns/cf-ddns.env"
+show_help() {
+  cat <<'USAGE'
+CloudCaddy Dynamic DNS updater
 
-if [ ! -f "$ENV_FILE" ]; then
+Usage: $0 [-help]
+
+Reads configuration from /opt/cloudflare-ddns/cf-ddns.env and updates Cloudflare
+A records to match the machine's current public IP. Configuration can specify a
+single zone/record pair via ZONE_NAME and RECORD_NAME or multiple pairs using
+arrays ZONES and RECORDS of equal length. When WILDCARD=1 is set in the
+configuration, a wildcard CNAME ("*.zone") pointing to the zone is ensured for
+each zone.
+
+Options:
+  -help    Display this message and exit
+USAGE
+}
+
+if [[ "$1" == "-help" ]]; then
+  show_help
+  exit 0
+fi
+
+ENV_FILE="/opt/cloudflare-ddns/cf-ddns.env"
+if [[ ! -f "$ENV_FILE" ]]; then
   echo "Missing config file: $ENV_FILE"
   exit 1
 fi
-
 # shellcheck disable=SC1090
 source "$ENV_FILE"
 
-# === Check required variables ===
-if [ -z "$CF_API_TOKEN" ] || [ -z "$ZONE_NAME" ] || [ -z "$RECORD_NAME" ]; then
-  echo "One or more required environment variables are missing."
-  exit 1
+# Support legacy single record config
+if [[ -n "${ZONES[*]}" && -n "${RECORDS[*]}" ]]; then
+  if [[ ${#ZONES[@]} -ne ${#RECORDS[@]} ]]; then
+    echo "ZONES and RECORDS arrays must have the same length"
+    exit 1
+  fi
+  zones=("${ZONES[@]}")
+  records=("${RECORDS[@]}")
+else
+  if [[ -z "$ZONE_NAME" || -z "$RECORD_NAME" ]]; then
+    echo "One or more required environment variables are missing."
+    exit 1
+  fi
+  zones=("$ZONE_NAME")
+  records=("$RECORD_NAME")
 fi
 
-# === Get current public IP ===
+WILDCARD=${WILDCARD:-0}
+
+ensure_wildcard() {
+  local zone=$1
+  local zone_id=$2
+  local wildcard_name="*.${zone}"
+
+  local info=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/${zone_id}/dns_records?name=${wildcard_name}" \
+    -H "Authorization: Bearer $CF_API_TOKEN" \
+    -H "Content-Type: application/json")
+  local id=$(echo "$info" | jq -r '.result[0].id')
+  if [[ -z "$id" || "$id" == "null" ]]; then
+    local data="{\"type\":\"CNAME\",\"name\":\"${wildcard_name}\",\"content\":\"${zone}\",\"ttl\":300,\"proxied\":false}"
+    curl -s -X POST "https://api.cloudflare.com/client/v4/zones/${zone_id}/dns_records" \
+      -H "Authorization: Bearer $CF_API_TOKEN" \
+      -H "Content-Type: application/json" \
+      --data "$data" >/dev/null
+    echo "Created wildcard CNAME for ${zone}"
+  fi
+}
+
 CURRENT_IP=$(curl -s https://api.ipify.org)
-if [ -z "$CURRENT_IP" ]; then
+if [[ -z "$CURRENT_IP" ]]; then
   echo "Failed to get public IP."
   exit 1
 fi
+
 echo "Current IP: $CURRENT_IP"
 
-# === Get Zone ID ===
-ZONE_ID=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones?name=${ZONE_NAME}" \
-  -H "Authorization: Bearer $CF_API_TOKEN" \
-  -H "Content-Type: application/json" | jq -r '.result[0].id')
+for i in "${!zones[@]}"; do
+  ZONE_NAME=${zones[$i]}
+  RECORD_NAME=${records[$i]}
+  echo "Processing $RECORD_NAME in zone $ZONE_NAME"
 
-if [ "$ZONE_ID" == "null" ] || [ -z "$ZONE_ID" ]; then
-  echo "Failed to fetch Zone ID for $ZONE_NAME"
-  exit 1
-fi
-
-# === Get Record ID and current Cloudflare IP ===
-RECORD_INFO=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?name=${RECORD_NAME}" \
-  -H "Authorization: Bearer $CF_API_TOKEN" \
-  -H "Content-Type: application/json")
-
-RECORD_ID=$(echo "$RECORD_INFO" | jq -r '.result[0].id')
-RECORD_IP=$(echo "$RECORD_INFO" | jq -r '.result[0].content')
-
-if [ -z "$RECORD_ID" ] || [ "$RECORD_ID" == "null" ]; then
-  echo "Failed to fetch DNS record for $RECORD_NAME"
-  exit 1
-fi
-
-echo "Cloudflare IP: $RECORD_IP"
-
-# === Update if needed ===
-if [ "$CURRENT_IP" != "$RECORD_IP" ]; then
-  echo "Updating DNS record..."
-  RESPONSE=$(curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${RECORD_ID}" \
+  ZONE_ID=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones?name=${ZONE_NAME}" \
     -H "Authorization: Bearer $CF_API_TOKEN" \
-    -H "Content-Type: application/json" \
-    --data "{\"type\":\"A\",\"name\":\"${RECORD_NAME}\",\"content\":\"${CURRENT_IP}\",\"ttl\":300,\"proxied\":false}")
+    -H "Content-Type: application/json" | jq -r '.result[0].id')
 
-  SUCCESS=$(echo "$RESPONSE" | jq -r '.success')
-  if [ "$SUCCESS" == "true" ]; then
-    echo "DNS record updated to $CURRENT_IP"
-  else
-    echo "Failed to update record:"
-    echo "$RESPONSE" | jq .
-    exit 1
+  if [[ -z "$ZONE_ID" || "$ZONE_ID" == "null" ]]; then
+    echo "Failed to fetch Zone ID for $ZONE_NAME"
+    continue
   fi
-else
-  echo "No update needed."
-fi
+
+  if [[ "$WILDCARD" == "1" ]]; then
+    ensure_wildcard "$ZONE_NAME" "$ZONE_ID"
+  fi
+
+  RECORD_INFO=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?name=${RECORD_NAME}" \
+    -H "Authorization: Bearer $CF_API_TOKEN" \
+    -H "Content-Type: application/json")
+  RECORD_ID=$(echo "$RECORD_INFO" | jq -r '.result[0].id')
+  RECORD_IP=$(echo "$RECORD_INFO" | jq -r '.result[0].content')
+
+  if [[ -z "$RECORD_ID" || "$RECORD_ID" == "null" ]]; then
+    echo "Failed to fetch DNS record for $RECORD_NAME"
+    continue
+  fi
+
+  echo "Cloudflare IP: $RECORD_IP"
+
+  if [[ "$CURRENT_IP" != "$RECORD_IP" ]]; then
+    echo "Updating DNS record..."
+    RESPONSE=$(curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${RECORD_ID}" \
+      -H "Authorization: Bearer $CF_API_TOKEN" \
+      -H "Content-Type: application/json" \
+      --data "{\"type\":\"A\",\"name\":\"${RECORD_NAME}\",\"content\":\"${CURRENT_IP}\",\"ttl\":300,\"proxied\":false}")
+    SUCCESS=$(echo "$RESPONSE" | jq -r '.success')
+    if [[ "$SUCCESS" == "true" ]]; then
+      echo "DNS record updated to $CURRENT_IP"
+    else
+      echo "Failed to update record:"
+      echo "$RESPONSE" | jq .
+    fi
+  else
+    echo "No update needed."
+  fi
+
+done

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,31 @@
 
 set -e
 
+usage() {
+  cat <<EOF
+CloudCaddy Installer
+
+Usage: $0 [-m] [-s] [-help]
+
+Options:
+  -m    Configure multiple zone/record pairs
+  -s    Also create wildcard *.zone CNAME pointing to the zone
+  -help Show this message and exit
+EOF
+}
+
+MULTI=false
+STAR=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -m) MULTI=true ;;
+    -s) STAR=true ;;
+    -help|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1"; usage; exit 1 ;;
+  esac
+  shift
+done
+
 echo "=== Cloudflare Dynamic DNS Installer (cloudcaddy) ==="
 
 # === Step 1: Install dependencies ===
@@ -20,17 +45,49 @@ fi
 # === Step 2: Prompt for Cloudflare config ===
 echo "[2/6] Collecting Cloudflare credentials..."
 read -rp "Enter your Cloudflare API token: " CF_API_TOKEN
-read -rp "Enter your Zone Name (e.g., example.com): " ZONE_NAME
-read -rp "Enter your Record Name (e.g., home.example.com): " RECORD_NAME
+if $MULTI; then
+  echo "Enter zone and record pairs (blank zone to finish):"
+  ZONES=()
+  RECORDS=()
+  while true; do
+    read -rp "Zone Name (e.g., example.com, blank to finish): " z
+    [[ -z "$z" ]] && break
+    read -rp "Record Name for $z (e.g., home.$z): " r
+    ZONES+=("$z")
+    RECORDS+=("$r")
+  done
+  if [[ ${#ZONES[@]} -eq 0 ]]; then
+    echo "No zones provided."
+    exit 1
+  fi
+else
+  read -rp "Enter your Zone Name (e.g., example.com): " ZONE_NAME
+  read -rp "Enter your Record Name (e.g., home.example.com): " RECORD_NAME
+fi
 
 # === Step 3: Write .env file ===
 echo "[3/6] Creating .env configuration..."
-ENV_CONTENT=$(cat <<EOF
+if $MULTI; then
+  ENV_CONTENT="CF_API_TOKEN=\"$CF_API_TOKEN\"\n"
+  ENV_CONTENT+="ZONES=("
+  for z in "${ZONES[@]}"; do ENV_CONTENT+="\"$z\" "; done
+  ENV_CONTENT+=")\nRECORDS=("
+  for r in "${RECORDS[@]}"; do ENV_CONTENT+="\"$r\" "; done
+  ENV_CONTENT+=")\n"
+else
+  ENV_CONTENT=$(cat <<EOF
 CF_API_TOKEN="$CF_API_TOKEN"
 ZONE_NAME="$ZONE_NAME"
 RECORD_NAME="$RECORD_NAME"
 EOF
 )
+fi
+
+if $STAR; then
+  ENV_CONTENT+="WILDCARD=1\n"
+else
+  ENV_CONTENT+="WILDCARD=0\n"
+fi
 
 # === Step 4: Deploy script and env file ===
 echo "[4/6] Deploying to /opt/cloudflare-ddns..."


### PR DESCRIPTION
## Summary
- support multiple zones and records with looping config
- add optional wildcard CNAME creation and helper flags
- provide help text and flag parsing for installer and updater scripts

## Testing
- `bash -n ddns.sh`
- `bash -n install.sh`
- `./ddns.sh -help`
- `./install.sh -help`


------
https://chatgpt.com/codex/tasks/task_e_689263fbaf8c8320a7e479c70e529ccd